### PR TITLE
fix: 'unable to start service init-kasmvnc-config' error on some file systems - notably ZFS

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -12,7 +12,8 @@ if [[ ! -f /config/.config/openbox/menu.xml ]]; then
   chown -R abc:abc /config/.config
 fi
 if [[ -f /usr/local/etc/kasmvnc/kasmvnc.yaml.lsio ]]; then
-  mv \
+  cp \
     /usr/local/etc/kasmvnc/kasmvnc.yaml.lsio \
     /usr/local/etc/kasmvnc/kasmvnc.yaml
+  rm /usr/local/etc/kasmvnc/kasmvnc.yaml.lsio
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-baseimage-kasmvnc/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

There is an issue that occurs on some file systems which results in the following error message:

`mv: cannot move '/usr/local/etc/kasmvnc/kasmvnc.yaml.lsio' to a subdirectory of itself, '/usr/local/etc/kasmvnc/kasmvnc.yaml'
s6-rc: warning: unable to start service init-kasmvnc-config: command exited 1`

And causes apps based on this base image to fail to run.

This is caused by usage of the move `mv` command to rename the `kasmvnc.yaml.lsio` file. The fix was to change the command from move `mv` to copy `cp` and then delete `rm` the original. This achieves the same goal while allowing the container to be used on these filesystems.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

It fixes the following issues:

https://github.com/linuxserver/docker-calibre/issues/134

https://github.com/linuxserver/docker-calibre/issues/130 (was closed but the issue wasn't fixed)



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This was tested by first running the original image that gave the error, and they connecting to the shell, and running the copy/remove commands manually which then fixed the container and allowed the app to run.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
