### PR TITLE
Fedora37 audiofix

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # default file copies first run
-if [[ ! -d /config/.config/openbox/autostart ]]; then
+if [[ ! -f /config/.config/openbox/autostart ]]; then
   mkdir -p /config/.config/openbox
   cp /defaults/autostart /config/.config/openbox/autostart
   chown -R abc:abc /config/.config/openbox

--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -16,3 +16,10 @@ if [[ -f /usr/local/etc/kasmvnc/kasmvnc.yaml.lsio ]]; then
     /usr/local/etc/kasmvnc/kasmvnc.yaml.lsio \
     /usr/local/etc/kasmvnc/kasmvnc.yaml
 fi
+
+# XDG Home
+printf "${HOME}/.XDG" > /run/s6/container_environment/XDG_RUNTIME_DIR
+if [ ! -d "${HOME}/.XDG" ]; then
+  mkdir -p ${HOME}/.XDG
+  chown abc:abc ${HOME}/.XDG
+fi

--- a/root/kasminit
+++ b/root/kasminit
@@ -33,12 +33,8 @@ if [[ ! -L $KASM_VNC_PATH/www/Downloads/Downloads ]]; then
   ln -sf $HOME/Downloads $KASM_VNC_PATH/www/Downloads/Downloads
 fi
 rm -rf $HOME/.config/pulse
-if [[ ! -d $HOME/.config/openbox/autostart ]]; then
-  mkdir -p $HOME/.config/openbox
-  cp /defaults/autostart $HOME/.config/openbox/autostart
-fi
 # Openbox config files
-if [[ ! -d $HOME/.config/openbox/autostart ]]; then
+if [[ ! -f $HOME/.config/openbox/autostart ]]; then
   mkdir -p $HOME/.config/openbox
   cp /defaults/autostart $HOME/.config/openbox/autostart
 fi


### PR DESCRIPTION
This sets an XDG_HOME to resolve a number of issues, but particularly audio not working in priv mode. 
Also ports over the logic changes from https://github.com/linuxserver/docker-baseimage-kasmvnc/pull/22 discovered by @spasche with duplicated logic and using a directory check for a file. 