### PR TITLE
Master 115 and add Lang support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:12-buster as wwwstage
 
-ARG KASMWEB_RELEASE="2b7e3321ae81cff99510738c2ecee1bcd2853d9b"
+ARG KASMWEB_RELEASE="933d5b7505e1357af6c32eda7fbbfd620c02fa64"
 
 RUN \
   echo "**** build clientside ****" && \
@@ -29,7 +29,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-alpine:3.19 as buildstage
 
-ARG KASMVNC_RELEASE="v1.2.0"
+ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
 
 COPY --from=wwwstage /build-out /www
 
@@ -236,7 +236,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:3.19
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG KASMBINS_RELEASE="1.14.0"
+ARG KASMBINS_RELEASE="1.15.0"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 LABEL "com.kasmweb.image"="true"
@@ -267,9 +267,13 @@ RUN \
     docker-cli-compose \
     ffmpeg \
     font-noto \
+    font-noto-all \
+    font-noto-cjk \
+    font-noto-emoji \
     fuse-overlayfs \
     gcompat \
     intel-media-driver \
+    lang \
     libgcc \
     libgomp \
     libjpeg-turbo \

--- a/Dockerfile
+++ b/Dockerfile
@@ -267,8 +267,6 @@ RUN \
     docker-cli-compose \
     ffmpeg \
     font-noto \
-    font-noto-all \
-    font-noto-cjk \
     font-noto-emoji \
     fuse-overlayfs \
     gcompat \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -277,8 +277,6 @@ RUN \
     docker-cli-compose \
     ffmpeg \
     font-noto \
-    font-noto-all \
-    font-noto-cjk \
     font-noto-emoji \
     fuse-overlayfs \
     gcompat \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@
 
 FROM node:12-buster as wwwstage
 
-ARG KASMWEB_RELEASE="2b7e3321ae81cff99510738c2ecee1bcd2853d9b"
+ARG KASMWEB_RELEASE="933d5b7505e1357af6c32eda7fbbfd620c02fa64"
 
 RUN \
   echo "**** install build deps ****" && \
@@ -34,7 +34,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.19 as buildstage
 
-ARG KASMVNC_RELEASE="v1.2.0"
+ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
 
 COPY --from=wwwstage /build-out /www
 
@@ -246,7 +246,7 @@ FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.19
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG KASMBINS_RELEASE="1.14.0"
+ARG KASMBINS_RELEASE="1.15.0"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 LABEL "com.kasmweb.image"="true"
@@ -277,8 +277,12 @@ RUN \
     docker-cli-compose \
     ffmpeg \
     font-noto \
+    font-noto-all \
+    font-noto-cjk \
+    font-noto-emoji \
     fuse-overlayfs \
     gcompat \
+    lang \
     libgcc \
     libgomp \
     libjpeg-turbo \

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ All base images are built for x86_64 and aarch64 platforms.
 
 | Distro | Current Tag |
 | :----: | --- |
-| Alpine | alpine317 |
+| Alpine | alpine319 |
 | Arch | arch |
 | Debian | debianbullseye |
 | Debian | debianbookworm |
-| Fedora | fedora38 |
+| Fedora | fedora39 |
 | Ubuntu | ubuntujammy |
 
 # I like to read documentation

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All application settings are passed via environment variables:
 | START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
 | DRINODE | If mounting in /dev/dri for [DRI3 GPU Acceleration](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html) allows you to specify the device to use |
 | DISABLE_IPV6 | If set to true or any value this will disable IPv6 |
+| LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
 
 # Available Distros
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,6 +36,7 @@ full_custom_readme: |
   | START_DOCKER | If set to false a container with privilege will not automatically start the DinD Docker setup. |
   | DRINODE | If mounting in /dev/dri for [DRI3 GPU Acceleration](https://www.kasmweb.com/kasmvnc/docs/master/gpu_acceleration.html) allows you to specify the device to use |
   | DISABLE_IPV6 | If set to true or any value this will disable IPv6 |
+  | LC_ALL | Set the Language for the container to run as IE `fr_FR.UTF-8` `ar_AE.UTF-8` |
 
   # Available Distros
   

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,11 +43,11 @@ full_custom_readme: |
   
   | Distro | Current Tag |
   | :----: | --- |
-  | Alpine | alpine317 |
+  | Alpine | alpine319 |
   | Arch | arch |
   | Debian | debianbullseye |
   | Debian | debianbookworm |
-  | Fedora | fedora38 |
+  | Fedora | fedora39 |
   | Ubuntu | ubuntujammy |
 
   # I like to read documentation

--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -23,3 +23,9 @@ if [ ! -d "${HOME}/.XDG" ]; then
   mkdir -p ${HOME}/.XDG
   chown abc:abc ${HOME}/.XDG
 fi
+
+# Locale Support
+if [ ! -z ${LC_ALL+x} ]; then
+  printf "${LC_ALL%.UTF-8}" > /run/s6/container_environment/LANGUAGE
+  printf "${LC_ALL}" > /run/s6/container_environment/LANG
+fi

--- a/root/kasminit
+++ b/root/kasminit
@@ -8,6 +8,12 @@ function clean () {
 trap clean SIGINT SIGTERM
 clean
 
+# Lang
+if [ ! -z ${LC_ALL+x} ]; then
+  export LANGUAGE="${LC_ALL%.UTF-8}"
+  export LANG="${LC_ALL}"
+fi
+
 # Environment
 export HOME=/home/kasm-user
 export KASM_VNC_PATH=/usr/share/kasmvnc


### PR DESCRIPTION
This bumps to the current KasmVNC release and adds language support to all images based on these with `LC_ALL`.
Previously the images were installing lang support for packages but logic was stashed at https://github.com/linuxserver/docker-mods/tree/universal-internationalization as a mod. The additions are minimal from a size standpoint adding the emoji font, core noto font, and generating locales in the base image. This does not add huge fonts for stuff like Chinese/Japanese/Korean those would still need to be added via a package mod if a user needed support. 

This adds a large feature of multi monitor support which has been tested across all flavors (Displays in the menu), try it here: 

```
docker run --rm -it --shm-size="1gb" -e LC_ALL=ru_RU.UTF-8 -p 3000:3000  taisun/random-images:debian-kde-demo bash
```

The PRs are focused on the current active branches: 

ubuntujammy
master (alpine319)
debianbookworm
fedora39
arch

The remaining branches will get sunsetted when I can confirm we are not using them anywhere and in the mean time receive package updates only. This will take time to waterfall to active repos using this base but some I will kick off manually post merge like webtop. 