### PR TITLE
Debian add lang support and updates for 115 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:12-buster as wwwstage
 
-ARG KASMWEB_RELEASE="2b7e3321ae81cff99510738c2ecee1bcd2853d9b"
+ARG KASMWEB_RELEASE="933d5b7505e1357af6c32eda7fbbfd620c02fa64"
 
 RUN \
   echo "**** build clientside ****" && \
@@ -30,7 +30,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-debian:bookworm as buildstage
 
-ARG KASMVNC_RELEASE="v1.2.0"
+ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
 
 COPY --from=wwwstage /build-out /www
 
@@ -220,7 +220,7 @@ FROM ghcr.io/linuxserver/baseimage-debian:bookworm
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG KASMBINS_RELEASE="1.14.0"
+ARG KASMBINS_RELEASE="1.15.0"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 LABEL "com.kasmweb.image"="true"
@@ -266,6 +266,8 @@ RUN \
     dbus-x11 \
     ffmpeg \
     file \
+    fonts-noto-color-emoji \
+    fonts-noto-core \
     fuse-overlayfs \
     intel-media-va-driver \
     libdatetime-perl \
@@ -299,6 +301,7 @@ RUN \
     libxshmfence1 \
     libxtst6 \
     libyaml-tiny-perl \
+    locales-all \
     mesa-va-drivers \
     nginx \
     nodejs \
@@ -384,7 +387,9 @@ RUN \
   echo 'hosts: files dns' > /etc/nsswitch.conf && \
   usermod -aG docker abc && \
   echo "**** locales ****" && \
-  localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+  for LOCALE in $(curl -sL https://raw.githubusercontent.com/thelamer/lang-stash/master/langs); do \
+    localedef -i $LOCALE -f UTF-8 $LOCALE.UTF-8; \
+  done && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@
 
 FROM node:12-buster as wwwstage
 
-ARG KASMWEB_RELEASE="2b7e3321ae81cff99510738c2ecee1bcd2853d9b"
+ARG KASMWEB_RELEASE="933d5b7505e1357af6c32eda7fbbfd620c02fa64"
 
 RUN \
   echo "**** install build deps ****" && \
@@ -34,7 +34,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-debian:arm64v8-bookworm as buildstage
 
-ARG KASMVNC_RELEASE="v1.2.0"
+ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
 
 COPY --from=wwwstage /build-out /www
 
@@ -224,7 +224,7 @@ FROM ghcr.io/linuxserver/baseimage-debian:arm64v8-bookworm
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG KASMBINS_RELEASE="1.14.0"
+ARG KASMBINS_RELEASE="1.15.0"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 LABEL "com.kasmweb.image"="true"
@@ -269,6 +269,8 @@ RUN \
     dbus-x11 \
     ffmpeg \
     file \
+    fonts-noto-color-emoji \
+    fonts-noto-core \
     fuse-overlayfs \
     libdatetime-perl \
     libfontenc1 \
@@ -301,6 +303,7 @@ RUN \
     libxshmfence1 \
     libxtst6 \
     libyaml-tiny-perl \
+    locales-all \
     mesa-va-drivers \
     nginx \
     nodejs \
@@ -385,7 +388,9 @@ RUN \
   echo 'hosts: files dns' > /etc/nsswitch.conf && \
   usermod -aG docker abc && \
   echo "**** locales ****" && \
-  localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+  for LOCALE in $(curl -sL https://raw.githubusercontent.com/thelamer/lang-stash/master/langs); do \
+    localedef -i $LOCALE -f UTF-8 $LOCALE.UTF-8; \
+  done && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \

--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -23,3 +23,9 @@ if [ ! -d "${HOME}/.XDG" ]; then
   mkdir -p ${HOME}/.XDG
   chown abc:abc ${HOME}/.XDG
 fi
+
+# Locale Support
+if [ ! -z ${LC_ALL+x} ]; then
+  printf "${LC_ALL%.UTF-8}" > /run/s6/container_environment/LANGUAGE
+  printf "${LC_ALL}" > /run/s6/container_environment/LANG
+fi

--- a/root/kasminit
+++ b/root/kasminit
@@ -8,6 +8,12 @@ function clean () {
 trap clean SIGINT SIGTERM
 clean
 
+# Lang
+if [ ! -z ${LC_ALL+x} ]; then
+  export LANGUAGE="${LC_ALL%.UTF-8}"
+  export LANG="${LC_ALL}"
+fi
+
 # Environment
 export HOME=/home/kasm-user
 export KASM_VNC_PATH=/usr/share/kasmvnc


### PR DESCRIPTION
This bumps to the current KasmVNC release and adds language support to all images based on these with `LC_ALL`.
Previously the images were installing lang support for packages but logic was stashed at https://github.com/linuxserver/docker-mods/tree/universal-internationalization as a mod. The additions are minimal from a size standpoint adding the emoji font, core noto font, and generating locales in the base image. This does not add huge fonts for stuff like Chinese/Japanese/Korean those would still need to be added via a package mod if a user needed support. 

This adds a large feature of multi monitor support which has been tested across all flavors (Displays in the menu), try it here: 

```
docker run --rm -it --shm-size="1gb" -e LC_ALL=ru_RU.UTF-8 -p 3000:3000  taisun/random-images:debian-kde-demo bash
```

The PRs are focused on the current active branches: 

ubuntujammy
master (alpine319)
debianbookworm
fedora39
arch

The remaining branches will get sunsetted when I can confirm we are not using them anywhere and in the mean time receive package updates only. This will take time to waterfall to active repos using this base but some I will kick off manually post merge like webtop. 