### PR TITLE
Fedora changes for 115 and add lang support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 FROM node:12-buster as wwwstage
 
-ARG KASMWEB_RELEASE="2b7e3321ae81cff99510738c2ecee1bcd2853d9b"
+ARG KASMWEB_RELEASE="933d5b7505e1357af6c32eda7fbbfd620c02fa64"
 
 RUN \
   echo "**** build clientside ****" && \
@@ -29,7 +29,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-fedora:39 as buildstage
 
-ARG KASMVNC_RELEASE="v1.2.0"
+ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
 
 COPY --from=wwwstage /build-out /www
 
@@ -224,7 +224,7 @@ FROM ghcr.io/linuxserver/baseimage-fedora:39
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG KASMBINS_RELEASE="1.14.0"
+ARG KASMBINS_RELEASE="1.15.0"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 LABEL "com.kasmweb.image"="true"
@@ -268,6 +268,10 @@ RUN \
     docker-compose-plugin \
     ffmpeg \
     fuse-overlayfs \
+    glibc-all-langpacks \
+    glibc-locale-source \
+    google-noto-emoji-fonts \
+    google-noto-sans-fonts \
     intel-media-driver \
     libjpeg-turbo \
     libstdc++ \
@@ -351,6 +355,10 @@ RUN \
     https://raw.githubusercontent.com/moby/moby/master/hack/dind && \
   chmod +x /usr/local/bin/dind && \
   usermod -aG docker abc && \
+  echo "**** configure locale ****" && \
+  for LOCALE in $(curl -sL https://raw.githubusercontent.com/thelamer/lang-stash/master/langs); do \
+    localedef -i $LOCALE -f UTF-8 $LOCALE.UTF-8; \
+  done && \
   echo "**** cleanup ****" && \
   dnf autoremove -y && \
   dnf clean all && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@
 
 FROM node:12-buster as wwwstage
 
-ARG KASMWEB_RELEASE="2b7e3321ae81cff99510738c2ecee1bcd2853d9b"
+ARG KASMWEB_RELEASE="933d5b7505e1357af6c32eda7fbbfd620c02fa64"
 
 RUN \
   echo "**** install build deps ****" && \
@@ -34,7 +34,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-fedora:arm64v8-39 as buildstage
 
-ARG KASMVNC_RELEASE="v1.2.0"
+ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
 
 COPY --from=wwwstage /build-out /www
 
@@ -229,7 +229,7 @@ FROM ghcr.io/linuxserver/baseimage-fedora:arm64v8-39
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG KASMBINS_RELEASE="1.14.0"
+ARG KASMBINS_RELEASE="1.15.0"
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 LABEL "com.kasmweb.image"="true"
@@ -272,6 +272,10 @@ RUN \
     docker-compose-plugin \
     ffmpeg \
     fuse-overlayfs \
+    glibc-all-langpacks \
+    glibc-locale-source \
+    google-noto-emoji-fonts \
+    google-noto-sans-fonts \
     libjpeg-turbo \
     libstdc++ \
     libwebp \
@@ -353,6 +357,10 @@ RUN \
     https://raw.githubusercontent.com/moby/moby/master/hack/dind && \
   chmod +x /usr/local/bin/dind && \
   usermod -aG docker abc && \
+  echo "**** configure locale ****" && \
+  for LOCALE in $(curl -sL https://raw.githubusercontent.com/thelamer/lang-stash/master/langs); do \
+    localedef -i $LOCALE -f UTF-8 $LOCALE.UTF-8; \
+  done && \
   echo "**** cleanup ****" && \
   dnf autoremove -y && \
   dnf clean all && \

--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -23,3 +23,9 @@ if [ ! -d "${HOME}/.XDG" ]; then
   mkdir -p ${HOME}/.XDG
   chown abc:abc ${HOME}/.XDG
 fi
+
+# Locale Support
+if [ ! -z ${LC_ALL+x} ]; then
+  printf "${LC_ALL%.UTF-8}" > /run/s6/container_environment/LANGUAGE
+  printf "${LC_ALL}" > /run/s6/container_environment/LANG
+fi

--- a/root/kasminit
+++ b/root/kasminit
@@ -8,6 +8,12 @@ function clean () {
 trap clean SIGINT SIGTERM
 clean
 
+# Lang
+if [ ! -z ${LC_ALL+x} ]; then
+  export LANGUAGE="${LC_ALL%.UTF-8}"
+  export LANG="${LC_ALL}"
+fi
+
 # Environment
 export HOME=/home/kasm-user
 export KASM_VNC_PATH=/usr/share/kasmvnc


### PR DESCRIPTION
This bumps to the current KasmVNC release and adds language support to all images based on these with `LC_ALL`.
Previously the images were installing lang support for packages but logic was stashed at https://github.com/linuxserver/docker-mods/tree/universal-internationalization as a mod. The additions are minimal from a size standpoint adding the emoji font, core noto font, and generating locales in the base image. This does not add huge fonts for stuff like Chinese/Japanese/Korean those would still need to be added via a package mod if a user needed support. 

This adds a large feature of multi monitor support which has been tested across all flavors (Displays in the menu), try it here: 

```
docker run --rm -it --shm-size="1gb" -e LC_ALL=ru_RU.UTF-8 -p 3000:3000  taisun/random-images:debian-kde-demo bash
```

The PRs are focused on the current active branches: 

ubuntujammy
master (alpine319)
debianbookworm
fedora39
arch

The remaining branches will get sunsetted when I can confirm we are not using them anywhere and in the mean time receive package updates only. This will take time to waterfall to active repos using this base but some I will kick off manually post merge like webtop. 