### PR TITLE
fedora39 add option to disable DRI keyboard shortcuts for decor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -323,6 +323,7 @@ RUN \
   sed -i \
     -e 's/NLIMC/NLMC/g' \
     -e 's|</applications>|  <application class="*"><maximized>yes</maximized></application>\n</applications>|' \
+    -e 's|</keyboard>|  <keybind key="C-S-d"><action name="ToggleDecorations"/></keybind>\n</keyboard>|' \
     /etc/xdg/openbox/rc.xml && \
   echo "**** user perms ****" && \
   echo "abc:abc" | chpasswd && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -325,6 +325,7 @@ RUN \
   sed -i \
     -e 's/NLIMC/NLMC/g' \
     -e 's|</applications>|  <application class="*"><maximized>yes</maximized></application>\n</applications>|' \
+    -e 's|</keyboard>|  <keybind key="C-S-d"><action name="ToggleDecorations"/></keybind>\n</keyboard>|' \
     /etc/xdg/openbox/rc.xml && \
   echo "**** user perms ****" && \
   echo "abc:abc" | chpasswd && \

--- a/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # Pass gpu flags if mounted
-if ls /dev/dri/renderD* 1> /dev/null 2>&1; then
+if ls /dev/dri/renderD* 1> /dev/null 2>&1 && [ -z ${DISABLE_DRI+x} ]; then
   HW3D="-hw3d"
 fi
 if [ -z ${DRINODE+x} ]; then


### PR DESCRIPTION
Adds keyboard binds for decorations and allows user to disable DRI3 acceleration. 