### PR TITLE
arch add option to disable DRI keyboard shortcuts for decor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -324,6 +324,7 @@ RUN \
   sed -i \
     -e 's/NLIMC/NLMC/g' \
     -e 's|</applications>|  <application class="*"><maximized>yes</maximized></application>\n</applications>|' \
+    -e 's|</keyboard>|  <keybind key="C-S-d"><action name="ToggleDecorations"/></keybind>\n</keyboard>|' \
     /etc/xdg/openbox/rc.xml && \
   echo "**** kasm support ****" && \
   mkdir -p /kasmbins && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -324,6 +324,7 @@ RUN \
   sed -i \
     -e 's/NLIMC/NLMC/g' \
     -e 's|</applications>|  <application class="*"><maximized>yes</maximized></application>\n</applications>|' \
+    -e 's|</keyboard>|  <keybind key="C-S-d"><action name="ToggleDecorations"/></keybind>\n</keyboard>|' \
     /etc/xdg/openbox/rc.xml && \
   echo "**** kasm support ****" && \
   mkdir -p /kasmbins && \

--- a/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # Pass gpu flags if mounted
-if ls /dev/dri/renderD* 1> /dev/null 2>&1; then
+if ls /dev/dri/renderD* 1> /dev/null 2>&1 && [ -z ${DISABLE_DRI+x} ]; then
   HW3D="-hw3d"
 fi
 if [ -z ${DRINODE+x} ]; then


### PR DESCRIPTION
Adds keyboard binds for decorations and allows user to disable DRI3 acceleration. 