### PR TITLE
Master proot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,6 +341,13 @@ RUN \
   usermod -s /bin/bash abc && \
   echo '%wheel ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/wheel && \
   adduser abc wheel && \
+  echo "**** proot-apps ****" && \
+  mkdir /proot-apps/ && \
+  PAPPS_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/proot-apps/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+  curl -L https://github.com/linuxserver/proot-apps/releases/download/${PAPPS_RELEASE}/proot-apps-x86_64.tar.gz \
+    | tar -xzf - -C /proot-apps/ && \
+  echo "${PAPPS_RELEASE}" > /proot-apps/pversion && \
   echo "**** kasm support ****" && \
   useradd \
     -u 1000 -U \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -345,6 +345,13 @@ RUN \
   usermod -s /bin/bash abc && \
   echo '%wheel ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/wheel && \
   adduser abc wheel && \
+  echo "**** proot-apps ****" && \
+  mkdir /proot-apps/ && \
+  PAPPS_RELEASE=$(curl -sX GET "https://api.github.com/repos/linuxserver/proot-apps/releases/latest" \
+    | awk '/tag_name/{print $4;exit}' FS='[""]') && \
+  curl -L https://github.com/linuxserver/proot-apps/releases/download/${PAPPS_RELEASE}/proot-apps-aarch64.tar.gz \
+    | tar -xzf - -C /proot-apps/ && \
+  echo "${PAPPS_RELEASE}" > /proot-apps/pversion && \
   echo "**** kasm support ****" && \
   useradd \
     -u 1000 -U \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ All base images are built for x86_64 and aarch64 platforms.
 | :----: | --- |
 | Alpine | alpine319 |
 | Arch | arch |
-| Debian | debianbullseye |
 | Debian | debianbookworm |
 | Fedora | fedora39 |
 | Fedora | fedora40 |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,15 @@ All base images are built for x86_64 and aarch64 platforms.
 | Debian | debianbullseye |
 | Debian | debianbookworm |
 | Fedora | fedora39 |
+| Fedora | fedora40 |
 | Ubuntu | ubuntujammy |
+| Ubuntu | ubuntunoble |
+
+# PRoot Apps
+
+All images include [proot-apps](https://github.com/linuxserver/proot-apps) which allow portable applications to be installed to persistent storage in the user's `$HOME` directory. These applications and their settings will persist upgrades of the base container and can be mounted into different flavors of KasmVNC containers. IE if you are running an Alpine based container you will be able to use the same `/config` directory mounted into a Debian based container and retain the same applications and settings as long as they were installed with `proot-apps install`.
+
+A list of linuxserver.io supported applications is located [HERE](https://github.com/linuxserver/proot-apps?tab=readme-ov-file#supported-apps).
 
 # I like to read documentation
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,7 +66,15 @@ full_custom_readme: |
   | Debian | debianbullseye |
   | Debian | debianbookworm |
   | Fedora | fedora39 |
+  | Fedora | fedora40 |
   | Ubuntu | ubuntujammy |
+  | Ubuntu | ubuntunoble |
+
+  # PRoot Apps
+
+  All images include [proot-apps](https://github.com/linuxserver/proot-apps) which allow portable applications to be installed to persistent storage in the user's `$HOME` directory. These applications and their settings will persist upgrades of the base container and can be mounted into different flavors of KasmVNC containers. IE if you are running an Alpine based container you will be able to use the same `/config` directory mounted into a Debian based container and retain the same applications and settings as long as they were installed with `proot-apps install`.
+
+  A list of linuxserver.io supported applications is located [HERE](https://github.com/linuxserver/proot-apps?tab=readme-ov-file#supported-apps).
 
   # I like to read documentation
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -63,7 +63,6 @@ full_custom_readme: |
   | :----: | --- |
   | Alpine | alpine319 |
   | Arch | arch |
-  | Debian | debianbullseye |
   | Debian | debianbookworm |
   | Fedora | fedora39 |
   | Fedora | fedora40 |

--- a/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-kasmvnc-config/run
@@ -45,3 +45,18 @@ if [[ ! -z ${NO_FULL+x} ]] && [[ ! -f /fulllock ]]; then
     /etc/xdg/openbox/rc.xml
   touch /fulllock
 fi
+
+# Add proot-apps
+if [ ! -f "${HOME}/.local/bin/proot-apps" ]; then
+  mkdir -p ${HOME}/.local/bin/
+  cp /proot-apps/* ${HOME}/.local/bin/
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bashrc
+  chown abc:abc \
+    ${HOME}/.bashrc \
+    ${HOME}/.local/ \
+    ${HOME}/.local/bin \
+    ${HOME}/.local/bin/{ncat,proot-apps,proot,jq,pversion}
+elif ! diff -q /proot-apps/pversion ${HOME}/.local/bin/pversion > /dev/null; then
+  cp /proot-apps/* ${HOME}/.local/bin/
+  chown abc:abc ${HOME}/.local/bin/{ncat,proot-apps,proot,jq,pversion}
+fi

--- a/root/kasminit
+++ b/root/kasminit
@@ -65,6 +65,14 @@ cp \
   /defaults/startwm.sh \
   $HOME/.vnc/xstartup
 touch $HOME/.vnc/.de-was-selected
+# Add proot-apps
+if [ ! -f "${HOME}/.local/bin/proot-apps" ]; then
+  mkdir -p ${HOME}/.local/bin/
+  cp /proot-apps/* ${HOME}/.local/bin/
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> $HOME/.bashrc
+elif ! diff -q /proot-apps/pversion ${HOME}/.local/bin/pversion > /dev/null; then
+  cp /proot-apps/* ${HOME}/.local/bin/
+fi
 
 ## KasmVNC init ##
 # Password


### PR DESCRIPTION
Adds proot-apps to the image copied into the users home directory on init. 
Adds docs for it.
Update the list of supported baseimages to include Noble and Fedora 40. 