### PR TITLE
Add Zink nvidia support arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,7 @@ ARG KCLIENT_RELEASE
 
 RUN \
   echo "**** install build deps ****" && \
-  pacman -Sy --noconfirm \
+  pacman -Syu --noconfirm \
     base-devel \
     curl \
     libpulse \
@@ -276,8 +276,11 @@ RUN \
     python3 \
     python-pyxdg \
     sudo \
+    vulkan-extra-layers \
     vulkan-intel \
     vulkan-radeon \
+    vulkan-swrast \
+    vulkan-tools \
     xf86-video-amdgpu \
     xf86-video-ati \
     xf86-video-intel \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -186,7 +186,7 @@ ARG KCLIENT_RELEASE
 
 RUN \
   echo "**** install build deps ****" && \
-  pacman -Sy --noconfirm \
+  pacman -Syu --noconfirm \
     base-devel \
     curl \
     libpulse \
@@ -279,7 +279,12 @@ RUN \
     python3 \
     python-pyxdg \
     sudo \
+    vulkan-broadcom \
+    vulkan-extra-layers \
+    vulkan-panfrost \
     vulkan-radeon \
+    vulkan-swrast \
+    vulkan-tools \
     xf86-video-amdgpu \
     xf86-video-nouveau \
     xf86-video-qxl \

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -1,2 +1,10 @@
 #!/usr/bin/env bash
+
+# Enable Nvidia GPU support if detected
+if which nvidia-smi; then
+  export LIBGL_KOPPER_DRI2=1
+  export MESA_LOADER_DRIVER_OVERRIDE=zink
+  export GALLIUM_DRIVER=zink
+fi
+
 /usr/bin/openbox-session

--- a/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # Pass gpu flags if mounted
-if ls /dev/dri/renderD* 1> /dev/null 2>&1 && [ -z ${DISABLE_DRI+x} ]; then
+if ls /dev/dri/renderD* 1> /dev/null 2>&1 && [ -z ${DISABLE_DRI+x} ] && ! which nvidia-smi; then
   HW3D="-hw3d"
 fi
 if [ -z ${DRINODE+x} ]; then


### PR DESCRIPTION
This adds nvidia support by adding env vars when the runtime is detected and not trying to bind an nvidia card to DRI3. 

This needs to be synced with a base build as there is a library linked to nodejs that got bumped. 