### PR TITLE
Add Zink nvidia support fedora40

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-fedora:40 as buildstage
 
-ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
+ARG KASMVNC_RELEASE="511e2ae542e95f5447a0a145bb54ced968e6cfec"
 
 COPY --from=wwwstage /build-out /www
 
@@ -282,6 +282,7 @@ RUN \
     mesa-libgbm \
     mesa-libGL \
     mesa-va-drivers \
+    mesa-vulkan-drivers \
     nginx \
     nodejs \
     openbox \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -34,7 +34,7 @@ RUN \
 
 FROM ghcr.io/linuxserver/baseimage-fedora:arm64v8-40 as buildstage
 
-ARG KASMVNC_RELEASE="d49d07b88113d28eb183ca7c0ca59990fae1153c"
+ARG KASMVNC_RELEASE="511e2ae542e95f5447a0a145bb54ced968e6cfec"
 
 COPY --from=wwwstage /build-out /www
 
@@ -285,6 +285,7 @@ RUN \
     mesa-libgbm \
     mesa-libGL \
     mesa-va-drivers \
+    mesa-vulkan-drivers \
     nginx \
     nodejs \
     openbox \

--- a/root/defaults/startwm.sh
+++ b/root/defaults/startwm.sh
@@ -1,2 +1,10 @@
 #!/usr/bin/env bash
+
+# Enable Nvidia GPU support if detected
+if which nvidia-smi; then
+  export LIBGL_KOPPER_DRI2=1
+  export MESA_LOADER_DRIVER_OVERRIDE=zink
+  export GALLIUM_DRIVER=zink
+fi
+
 /usr/bin/openbox-session

--- a/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kasmvnc/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 
 # Pass gpu flags if mounted
-if ls /dev/dri/renderD* 1> /dev/null 2>&1 && [ -z ${DISABLE_DRI+x} ]; then
+if ls /dev/dri/renderD* 1> /dev/null 2>&1 && [ -z ${DISABLE_DRI+x} ] && ! which nvidia-smi; then
   HW3D="-hw3d"
 fi
 if [ -z ${DRINODE+x} ]; then


### PR DESCRIPTION
This adds nvidia support by adding env vars when the runtime is detected and not trying to bind an nvidia card to DRI3. 