### PR TITLE
add mic support fedora40

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-kclient/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-kclient/run
@@ -1,5 +1,23 @@
 #!/usr/bin/with-contenv bash
 
+# Mic Setup
+if [ ! -f '/dev/shm/mic.lock' ]; then
+  until [ -f /defaults/pid ]; do
+    sleep .5
+  done
+  s6-setuidgid abc with-contenv pactl \
+    load-module module-pipe-source \
+    source_name=virtmic \
+    file=/defaults/mic.sock \
+    source_properties=device.description=LSIOMic \
+    format=s16le \
+    rate=44100 \
+    channels=1
+  s6-setuidgid abc with-contenv pactl \
+    set-default-source virtmic
+  touch /dev/shm/mic.lock
+fi
+
 # NodeJS wrapper
 cd /kclient
 exec s6-setuidgid abc \


### PR DESCRIPTION
This can be tested with this image: 

```
docker run --rm -it \
  -p 3001:3001 \
  --shm-size=1gb \
  taisun/random-images:lsio-mic bash
```

This needs to be synched with a Kclient release before merging but the test image is built off master. 